### PR TITLE
Updated to Couchbase Lite 3.2.1/React Native 0.76

### DIFF
--- a/expo-example/package-lock.json
+++ b/expo-example/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expo-example",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "expo-example",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@expo/vector-icons": "^14.0.2",
         "@gluestack-style/react": "^1.0.57",
@@ -49,7 +49,7 @@
       }
     },
     "..": {
-      "version": "0.2.1",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "workspaces": [
         "example"
@@ -69,11 +69,11 @@
         "commitlint": "^17.8.1",
         "del-cli": "^5.1.0",
         "eslint": "^8.51.0",
-        "eslint-config-prettier": "^9.0.0",
-        "eslint-plugin-prettier": "^5.0.1",
+        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-prettier": "^5.2.1",
         "fast-xml-parser": "~4.4.1",
         "jest": "^29.7.0",
-        "prettier": "^3.3.3",
+        "prettier": "^3.4.1",
         "react": "18.3.1",
         "react-native": "0.76.2",
         "react-native-builder-bob": "^0.32.1",

--- a/expo-example/package.json
+++ b/expo-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "expo-example",
   "main": "expo-router/entry",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "scripts": {
     "clean": "npm run prebuild:clean",
     "prebuild": "cd .. && npm run build && cd expo-example && npx expo prebuild",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cbl-reactnative",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cbl-reactnative",
-      "version": "0.2.1",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "workspaces": [
         "example"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cbl-reactnative",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "Couchbase Lite Enterprise for React Native",
   "author": "Dev Experience/Ecosystem Team @ Couchbase",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Couchbase Lite 3.2.1 support
- React Native 0.76.x support
- Expo Example updated to Expo 52.0.11
- Updated Documents and Blob API to support new way of processing documents due to changes made in cbl-ionic to support nested arrays in Android
- Added Test Runners and support for cblite-js-tests
- Started working on fixes for emitter problems with listeners
- Validated all implemented tests pass