### PR TITLE
feat: add reo-census for npm install tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "cbl-reactnative",
-  "version": "0.6.3",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cbl-reactnative",
-      "version": "0.6.3",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "workspaces": [
         "example"
       ],
       "dependencies": {
-        "react-native-uuid": "^2.0.2"
+        "react-native-uuid": "^2.0.2",
+        "reo-census": "^1.2.8"
       },
       "devDependencies": {
         "@commitlint/config-conventional": "^17.8.1",
@@ -14695,6 +14696,16 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/reo-census": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/reo-census/-/reo-census-1.2.8.tgz",
+      "integrity": "sha512-UMwpNwOieUTeymIITWCbo0In0FHGWZwnXIIYphpCPO/Bjl5z/385DWLnTxBcfFFCH/r/fEq/TZ0ivlPb6Smi9Q==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "!src/cblite-js/cblite-tests"
   ],
   "dependencies": {
-    "react-native-uuid": "^2.0.2"
+    "react-native-uuid": "^2.0.2",
+    "reo-census": "^1.2.8"
   },
   "devDependencies": {
     "@commitlint/config-conventional": "^17.8.1",


### PR DESCRIPTION
This has been tested and we are getting the analytics on their platform.

https://roverly.notion.site/Set-up-NPM-Package-Installs-Tracking-on-Reo-Dev-31a33e0c3ba280eca09ff18dfb176bcf

<img width="962" height="884" alt="Screenshot 2026-03-12 at 2 33 20 PM" src="https://github.com/user-attachments/assets/f6b7896d-33f3-4dee-a97c-0673aea80e2a" />

